### PR TITLE
Makefile: allow building from source without git

### DIFF
--- a/Makefile.INCLUDE
+++ b/Makefile.INCLUDE
@@ -15,7 +15,7 @@
 
 .SUFFIXES:
 
-VERSION=$(shell cat `git rev-parse --show-toplevel`/VERSION)
+VERSION?=$(shell cat `git rev-parse --show-toplevel`/VERSION)
 
 OS=$(shell uname)
 ARCH=$(shell uname -m)


### PR DESCRIPTION
This allows for building from a source tarball/zip using
VERSION=$VERSION make build
